### PR TITLE
Add X509Extension.set_data to PyOpenSSL

### DIFF
--- a/frankengen/franken_core.py
+++ b/frankengen/franken_core.py
@@ -1,6 +1,8 @@
 from OpenSSL import crypto
 import random
 import collections
+from datetime import datetime
+from datetime import timedelta
 import sys
 
 def get_extension_dict(certs):
@@ -71,7 +73,7 @@ def generate_cert(certificates, pkey, signing_key, issuer, max_extensions, \
             extension.set_critical(1 - extension.get_critical())
         if random.random() < ext_mod_probability:
             randstr = "".join( chr(random.randint(0, 255)) for i in range(7))
-            extension.set_data(randstr)
+            extension.set_data(randstr.encode())
         
     cert.add_extensions(new_extensions)
     if not issuer is None:

--- a/frankengen/franken_core.py
+++ b/frankengen/franken_core.py
@@ -49,13 +49,13 @@ def generate_cert(certificates, pkey, signing_key, issuer, max_extensions, \
     # overwrite the timestamps if asked by the user
     if random.random() < invalid_ts_probability:
         if random.random() < 0.5:
-            notvalidyet = b(datetime.now() + timedelta(days=1).\
-                                strftime("%Y%m%d%H%M%SZ"))
+            notvalidyet = (datetime.now() + timedelta(days=1)).\
+                                strftime("%Y%m%d%H%M%SZ").encode()
             cert.set_notBefore(notvalidyet)
         else:
-            expired = b(datetime.now() - timedelta(days=1).\
-                                strftime("%Y%m%d%H%M%SZ"))
-            cert.set_notBefore(expired)
+            expired = (datetime.now() - timedelta(days=1)).\
+                                strftime("%Y%m%d%H%M%SZ").encode()
+            cert.set_notAfter(expired)
                 
         
     # handle the extensions

--- a/pyopenssl-19.1.0/src/OpenSSL/crypto.py
+++ b/pyopenssl-19.1.0/src/OpenSSL/crypto.py
@@ -875,6 +875,17 @@ class X509Extension(object):
         extension = _lib.X509_EXTENSION_create_by_OBJ(_ffi.NULL, obj, critical, data)
         self._extension = _ffi.gc(extension, _lib.X509_EXTENSION_free)
 
+    def set_data(self, data):
+        """
+        Sets the data of the X509 extension, encoded as ASN.1.
+
+        :param data: ASN.1 data to set.
+        :type data: :py:data:`bytes`
+
+        .. versionadded:: Custom for Frankencert
+        """
+        _lib.X509_EXTENSION_set_data(self._extension, data)
+
 
 class X509Req(object):
     """

--- a/pyopenssl-19.1.0/src/OpenSSL/crypto.py
+++ b/pyopenssl-19.1.0/src/OpenSSL/crypto.py
@@ -884,7 +884,12 @@ class X509Extension(object):
 
         .. versionadded:: Custom for Frankencert
         """
-        _lib.X509_EXTENSION_set_data(self._extension, data)
+        obj = _lib.X509_EXTENSION_get_object(self._extension)
+        result_buffer = _ffi.new("ASN1_STRING *")
+        _lib.ASN1_STRING_set(result_buffer, data, -1)
+        octet_result = _ffi.cast('ASN1_OCTET_STRING*', result_buffer)
+        extension = _lib.X509_EXTENSION_create_by_OBJ(_ffi.NULL, obj, self.get_critical(), octet_result)
+        self._extension = _ffi.gc(extension, _lib.X509_EXTENSION_free)
 
 
 class X509Req(object):


### PR DESCRIPTION
Fix some issues hidden by the default options. Add X509Extension.set_data to PyOpenSSL. Convert input to bytes, and fix datetime usage for invalid_ts_prob option