### PR TITLE
Fix pyOpenSSL dependency version in setup.py

### DIFF
--- a/pyopenssl-19.1.0/setup.py
+++ b/pyopenssl-19.1.0/setup.py
@@ -94,7 +94,7 @@ if __name__ == "__main__":
         package_dir={"": "src"},
         install_requires=[
             # Fix cryptographyMinimum in tox.ini when changing this!
-            "cryptography>=2.8",
+            "cryptography>=2.8,<=3.4.8",
             "six>=1.5.2"
         ],
         extras_require={


### PR DESCRIPTION
Older versions of pyOpenSSL do not work with latest versions of cryptography, so we need to provide an upper bound while setting version limits.

I encountered this (https://github.com/pypa/pip/issues/8085) alongside some other errors when using latest cryptography versions. I tested Cryptography 2.8 and 3.4.8 and these both worked fine with Frankencerts, so believe this range should work well. 